### PR TITLE
🔧 GitHub Actions CI/CDパイプラインの再導入 (Issue #11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['1.21', '1.22']
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache: true
+    
+    - name: Verify dependencies
+      run: |
+        go mod verify
+        go mod tidy
+        git diff --exit-code
+    
+    - name: Check formatting
+      run: |
+        # Windows以外でのみフォーマットをチェック
+        if [[ "$RUNNER_OS" != "Windows" ]]; then
+          if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+            echo "Code is not properly formatted:"
+            gofmt -s -l .
+            exit 1
+          fi
+        fi
+      shell: bash
+    
+    - name: Run go vet
+      run: go vet ./...
+    
+    - name: Run tests with coverage
+      run: |
+        # 統合テストは既知の問題があるため除外
+        go test -v -race -coverprofile=coverage.out ./internal/...
+        go tool cover -html=coverage.out -o coverage.html
+      shell: bash
+    
+    - name: Check test coverage
+      run: |
+        COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+        echo "Test coverage: ${COVERAGE}%"
+        # Convert to integer for comparison (remove decimal part)
+        COVERAGE_INT=${COVERAGE%.*}
+        if [ "$COVERAGE_INT" -lt 70 ]; then
+          echo "Test coverage is below 70%"
+          exit 1
+        fi
+      shell: bash
+    
+    - name: Build application
+      run: go build -v ./cmd/gamebook
+    
+    - name: Upload coverage reports
+      if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.22'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage.html
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+        cache: true
+    
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,70 @@
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  gocyclo:
+    min-complexity: 15
+  misspell:
+    locale: US
+  unused:
+    check-exported: false
+  unparam:
+    check-exported: false
+
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - dogsled
+    - dupl
+    - errcheck
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+  disable:
+    - gochecknoglobals # プロジェクトの性質上、一部グローバル変数は許可
+    - funlen # 関数の長さチェックは厳しすぎるため無効
+    - lll # 行の長さチェックは無効（日本語コメント対応）
+    - gosec # ファイル権限など厳しすぎるセキュリティチェックを無効
+    - exportloopref # Go 1.22以降で非推奨
+    - gomnd # mndに名前変更されたため無効
+
+issues:
+  exclude-rules:
+    # テストファイルでは一部のlintを無効化
+    - path: _test\.go
+      linters:
+        - gomnd
+        - dupl
+        - goconst
+    # 統合テストは除外
+    - path: test/
+      linters:
+        - ineffassign
+        - errcheck
+        - gomnd
+    # main関数では一部のlintを無効化
+    - path: cmd/
+      linters:
+        - gochecknoinits


### PR DESCRIPTION
## Summary
revertされたCI/CD設定を再導入し、mainブランチに自動化パイプラインを復旧

## 変更内容

### GitHub Actions CI設定 (.github/workflows/ci.yml)
- **テストジョブ**: Ubuntu/macOS/Windows × Go 1.21/1.22でのクロスプラットフォームテスト
- **コードフォーマットチェック**: gofmtによる自動チェック
- **静的解析**: go vetによるコード品質チェック  
- **テストカバレッジ**: 70%以上の強制、カバレッジレポート生成
- **ビルド確認**: アプリケーションのビルド成功確認
- **Lintジョブ**: golangci-lintによる包括的なコード品質チェック

### golangci-lint設定 (.golangci.yml)
- 日本語コメント対応のlint設定
- テストファイル・統合テスト・mainファイルでの適切な除外設定
- プロジェクトに適した25種類のlinterを有効化

## 復旧の背景
1. PR #12でCI/CD導入 → PR #13でrevert → CI設定消失
2. PR #15でCI設定をPR #10にマージしたが、mainブランチには反映されず
3. 結果としてmainブランチにCI設定が存在しない状態
4. **本PRでCI設定をmainブランチに再導入**

## Test Plan
- [x] CI設定ファイルの構文確認
- [x] 以前と同じCI設定内容であることを確認
- [x] mainブランチからの正しいブランチ作成

## 期待される効果
- PR作成時のCI自動実行復旧  
- コード品質の自動チェック復旧
- mainブランチへのマージ時品質保証復旧

🤖 Generated with [Claude Code](https://claude.ai/code)