### PR TITLE
✨ v0.2.1: 段落順序依存問題の解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ gh issue create --template ai_bug_report
 - **v0.1.5**: Interactive mode with PTerm rich UI ✅ **Complete**
 - **v0.2.0**: PTerm visualization features (dynamic flow, interactive 2D maps) ✅ **Complete**
 - **v0.2.1**: 段落順序依存問題の解消 - プレイテスターフィードバック対応 (Issue #43, #46)
+- **v0.2.2**: フロー図の視認性と情報表示の改善 - 追加プレイテスターフィードバック対応 (Issue #53)
 - **v0.3.0**: 操作性の大幅改善 - コマンド短縮とショートカット強化 (Issue #44)
 - **v0.4.0**: スマートフォン連携 - WebUI実装によるハンズフリー操作 (Issue #45)
 - **v0.5.0**: 東西南北対応マップ機能の再設計 - 方向概念とマップ座標系の実装 (Issue #47)

--- a/cmd/gamebook/choice_commands.go
+++ b/cmd/gamebook/choice_commands.go
@@ -75,9 +75,11 @@ var selectChoiceCmd = &cobra.Command{
 		}
 		choiceIndex := choiceNum - 1 // 1ベースから0ベースに変換
 
-		// 選択肢を選択して移動
-		if err := currentGame.SelectChoiceAndMove(paragraphNum, choiceIndex); err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
+		// 優雅なエラーハンドリングを使用して選択肢を選択・移動
+		moveResult := currentGame.SelectChoiceAndMoveWithGracefulHandling(paragraphNum, choiceIndex)
+
+		if !moveResult.Success {
+			fmt.Fprintf(os.Stderr, "エラー: %s\n", moveResult.WarningMessage)
 			return
 		}
 
@@ -87,8 +89,15 @@ var selectChoiceCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("パラグラフ %d の選択肢 %d を選択し、パラグラフ %d に移動しました。\n",
-			paragraphNum, choiceNum, currentGame.Current.Number)
+		// 結果の表示
+		if moveResult.HasWarning {
+			fmt.Printf("⚠️  警告: %s\n", moveResult.WarningMessage)
+			fmt.Printf("パラグラフ %d の選択肢 %d を選択しました（移動先が未定義のため現在位置を維持）。\n",
+				paragraphNum, choiceNum)
+		} else {
+			fmt.Printf("パラグラフ %d の選択肢 %d を選択し、パラグラフ %d に移動しました。\n",
+				paragraphNum, choiceNum, currentGame.Current.Number)
+		}
 	},
 }
 

--- a/cmd/gamebook/commands.go
+++ b/cmd/gamebook/commands.go
@@ -112,18 +112,28 @@ func (e *CLIExecutor) ExecuteSelectCommand(paragraphNum int, choiceIndex int) er
 		return fmt.Errorf("エラー: ゲームブックが選択されていません。")
 	}
 
-	// 選択肢を選択して移動
-	if err := currentGame.SelectChoiceAndMove(paragraphNum, choiceIndex); err != nil {
-		return fmt.Errorf("エラー: %v", err)
+	// 優雅なエラーハンドリングを使用して選択肢を選択・移動
+	moveResult := currentGame.SelectChoiceAndMoveWithGracefulHandling(paragraphNum, choiceIndex)
+
+	if !moveResult.Success {
+		return fmt.Errorf("エラー: %s", moveResult.WarningMessage)
 	}
 
 	// 保存
-	if err := repo.Save(currentGame); err != nil {
-		return fmt.Errorf("保存エラー: %v", err)
+	if saveErr := repo.Save(currentGame); saveErr != nil {
+		return fmt.Errorf("保存エラー: %w", saveErr)
 	}
 
-	fmt.Printf("パラグラフ %d の選択肢 %d を選択し、パラグラフ %d に移動しました。\n",
-		paragraphNum, choiceIndex+1, currentGame.Current.Number)
+	// 結果の表示
+	if moveResult.HasWarning {
+		fmt.Printf("⚠️  警告: %s\n", moveResult.WarningMessage)
+		fmt.Printf("パラグラフ %d の選択肢 %d を選択しました（移動先が未定義のため現在位置を維持）。\n",
+			paragraphNum, choiceIndex+1)
+	} else {
+		fmt.Printf("パラグラフ %d の選択肢 %d を選択し、パラグラフ %d に移動しました。\n",
+			paragraphNum, choiceIndex+1, currentGame.Current.Number)
+	}
+
 	return nil
 }
 
@@ -172,6 +182,20 @@ func (e *CLIExecutor) ExecuteShowCommand() error {
 		if err := e.showVisualization(); err != nil {
 			fmt.Printf("可視化エラー: %v\n", err)
 		}
+	}
+
+	// 保留参照情報の表示
+	pendingTargets := currentGame.GetAllPendingTargets()
+	if len(pendingTargets) > 0 {
+		fmt.Printf("\n⏳ 未定義段落への参照: ")
+		for i, target := range pendingTargets {
+			if i > 0 {
+				fmt.Printf(", ")
+			}
+			fmt.Printf("#%d", target)
+		}
+		fmt.Println()
+		fmt.Println("   上記の段落を追加すると、参照が自動的に解決されます。")
 	}
 
 	// 他のパラグラフ（現在位置以外の最近追加分）

--- a/internal/domain/gamebook.go
+++ b/internal/domain/gamebook.go
@@ -1,18 +1,22 @@
 package domain
 
+import "fmt"
+
 // Gamebook はゲームブック全体を管理する
 type Gamebook struct {
-	Title      string
-	Paragraphs map[int]*Paragraph
-	Current    *Paragraph
+	Title             string
+	Paragraphs        map[int]*Paragraph
+	Current           *Paragraph
+	pendingReferences *PendingReferenceManager // 保留参照管理
 }
 
 // NewGamebook は新しいゲームブックを作成する
 func NewGamebook(title string) *Gamebook {
 	return &Gamebook{
-		Title:      title,
-		Paragraphs: make(map[int]*Paragraph),
-		Current:    nil,
+		Title:             title,
+		Paragraphs:        make(map[int]*Paragraph),
+		Current:           nil,
+		pendingReferences: NewPendingReferenceManager(),
 	}
 }
 
@@ -22,6 +26,10 @@ func (g *Gamebook) AddParagraph(p *Paragraph) error {
 		return ErrDuplicateParagraph
 	}
 	g.Paragraphs[p.Number] = p
+
+	// 保留参照を解決
+	_ = g.pendingReferences.ResolveReference(p.Number)
+
 	return nil
 }
 
@@ -78,7 +86,15 @@ func (g *Gamebook) AddChoiceToParagraph(paragraphNumber int, description string,
 	if err != nil {
 		return err
 	}
+
+	// 選択肢を追加
 	p.AddChoice(description, targetNumber)
+
+	// 遷移先が未定義の場合は保留参照として記録
+	if _, targetExists := g.Paragraphs[targetNumber]; !targetExists {
+		_ = g.pendingReferences.AddReference(paragraphNumber, description, targetNumber)
+	}
+
 	return nil
 }
 
@@ -104,4 +120,55 @@ type ExplorationStats struct {
 	VisitedParagraphs int
 	TotalChoices      int
 	SelectedChoices   int
+}
+
+// MoveResult は移動結果を表す
+type MoveResult struct {
+	Success        bool   // 移動が成功したか
+	HasWarning     bool   // 警告があるか
+	WarningMessage string // 警告メッセージ
+}
+
+// GetAllPendingTargets は全ての保留対象段落番号を取得する
+func (g *Gamebook) GetAllPendingTargets() []int {
+	return g.pendingReferences.GetAllPendingTargets()
+}
+
+// SelectChoiceAndMoveWithGracefulHandling は選択肢を選択し、優雅な移動処理を行う
+func (g *Gamebook) SelectChoiceAndMoveWithGracefulHandling(paragraphNumber int, choiceIndex int) MoveResult {
+	p, err := g.GetParagraph(paragraphNumber)
+	if err != nil {
+		return MoveResult{
+			Success:        false,
+			HasWarning:     true,
+			WarningMessage: "段落が見つかりません: " + err.Error(),
+		}
+	}
+
+	if selectErr := p.SelectChoice(choiceIndex); selectErr != nil {
+		return MoveResult{
+			Success:        false,
+			HasWarning:     true,
+			WarningMessage: "選択肢の選択に失敗: " + selectErr.Error(),
+		}
+	}
+
+	// 選択された選択肢の遷移先に移動を試行
+	targetNumber := p.Choices[choiceIndex].TargetNumber
+	moveErr := g.MoveTo(targetNumber)
+
+	if moveErr != nil {
+		// 移動失敗時は警告付きで成功とする（優雅な処理）
+		return MoveResult{
+			Success:        true,
+			HasWarning:     true,
+			WarningMessage: fmt.Sprintf("段落%dは未定義です。後で追加してください。", targetNumber),
+		}
+	}
+
+	return MoveResult{
+		Success:        true,
+		HasWarning:     false,
+		WarningMessage: "",
+	}
 }

--- a/internal/domain/gamebook_test.go
+++ b/internal/domain/gamebook_test.go
@@ -142,3 +142,72 @@ func TestGamebook_GetExplorationStats(t *testing.T) {
 	assert.Equal(t, 3, stats.TotalChoices)      // 2+1+0
 	assert.Equal(t, 1, stats.SelectedChoices)   // 北へのみ選択
 }
+
+// TestGamebook_AddChoiceToParagraph_WithPendingReference 保留参照を使った選択肢追加テスト
+func TestGamebook_AddChoiceToParagraph_WithPendingReference(t *testing.T) {
+	t.Run("正常系：未定義段落への選択肢追加を許可", func(t *testing.T) {
+		// Given
+		gb := NewGamebook("テストブック")
+		p1 := NewParagraph(1, "開始")
+		_ = gb.AddParagraph(p1)
+
+		// When: 未定義段落23への選択肢を追加
+		err := gb.AddChoiceToParagraph(1, "洞窟に入る", 23)
+
+		// Then: エラーなく追加され、保留参照として記録される
+		assert.NoError(t, err)
+		assert.Len(t, p1.Choices, 1)
+		assert.Equal(t, "洞窟に入る", p1.Choices[0].Description)
+		assert.Equal(t, 23, p1.Choices[0].TargetNumber)
+
+		// 保留参照が記録されていることを確認
+		pendingTargets := gb.GetAllPendingTargets()
+		assert.Contains(t, pendingTargets, 23)
+	})
+
+	t.Run("正常系：保留参照の自動解決", func(t *testing.T) {
+		// Given
+		gb := NewGamebook("テストブック")
+		p1 := NewParagraph(1, "開始")
+		_ = gb.AddParagraph(p1)
+
+		// 未定義段落への選択肢を追加
+		_ = gb.AddChoiceToParagraph(1, "洞窟に入る", 23)
+
+		// When: 対象段落を追加
+		p23 := NewParagraph(23, "暗い洞窟")
+		err := gb.AddParagraph(p23)
+
+		// Then: 保留参照が自動解決される
+		assert.NoError(t, err)
+		pendingTargets := gb.GetAllPendingTargets()
+		assert.NotContains(t, pendingTargets, 23)
+	})
+}
+
+// TestGamebook_MoveToWithGracefulHandling 未定義段落への移動の優雅な処理テスト
+func TestGamebook_MoveToWithGracefulHandling(t *testing.T) {
+	t.Run("警告付きで未定義段落への移動を記録", func(t *testing.T) {
+		// Given
+		gb := NewGamebook("テストブック")
+		p1 := NewParagraph(1, "開始")
+		p1.AddChoice("洞窟に入る", 23)
+		_ = gb.AddParagraph(p1)
+		_ = gb.MoveTo(1)
+
+		// When: 未定義段落への移動を試行
+		moveResult := gb.SelectChoiceAndMoveWithGracefulHandling(1, 0)
+
+		// Then: 警告情報と共に処理が続行される
+		assert.True(t, moveResult.Success)
+		assert.True(t, moveResult.HasWarning)
+		assert.Contains(t, moveResult.WarningMessage, "段落23")
+		assert.Contains(t, moveResult.WarningMessage, "未定義")
+
+		// 選択は記録される
+		assert.True(t, p1.Choices[0].Selected)
+
+		// 現在位置は変わらない（移動先が未定義のため）
+		assert.Equal(t, p1, gb.Current)
+	})
+}

--- a/internal/domain/pending_reference.go
+++ b/internal/domain/pending_reference.go
@@ -1,0 +1,64 @@
+package domain
+
+// PendingReference は未定義段落への参照を表す
+type PendingReference struct {
+	FromParagraph     int    // 参照元段落番号
+	ChoiceDescription string // 選択肢の説明
+	TargetParagraph   int    // 参照先段落番号
+}
+
+// PendingReferenceManager は未定義段落への参照を管理する
+type PendingReferenceManager struct {
+	references map[int][]PendingReference // 対象段落番号 -> 参照のリスト
+}
+
+// NewPendingReferenceManager は新しい保留参照管理を作成する
+func NewPendingReferenceManager() *PendingReferenceManager {
+	return &PendingReferenceManager{
+		references: make(map[int][]PendingReference),
+	}
+}
+
+// AddReference は保留参照を追加する
+func (m *PendingReferenceManager) AddReference(fromParagraph int, choiceDescription string, targetParagraph int) error {
+	ref := PendingReference{
+		FromParagraph:     fromParagraph,
+		ChoiceDescription: choiceDescription,
+		TargetParagraph:   targetParagraph,
+	}
+
+	m.references[targetParagraph] = append(m.references[targetParagraph], ref)
+	return nil
+}
+
+// GetReferences は指定された対象段落への保留参照を取得する
+func (m *PendingReferenceManager) GetReferences(targetParagraph int) []PendingReference {
+	refs, exists := m.references[targetParagraph]
+	if !exists {
+		return []PendingReference{}
+	}
+	// スライスのコピーを返して外部からの変更を防ぐ
+	result := make([]PendingReference, len(refs))
+	copy(result, refs)
+	return result
+}
+
+// ResolveReference は保留参照を解決して削除する
+func (m *PendingReferenceManager) ResolveReference(targetParagraph int) error {
+	delete(m.references, targetParagraph)
+	return nil
+}
+
+// GetAllPendingTargets は全ての保留対象段落番号を取得する
+func (m *PendingReferenceManager) GetAllPendingTargets() []int {
+	var targets []int
+	for target := range m.references {
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+// HasPendingReferences は保留参照が存在するかを確認する
+func (m *PendingReferenceManager) HasPendingReferences() bool {
+	return len(m.references) > 0
+}

--- a/internal/domain/pending_reference_test.go
+++ b/internal/domain/pending_reference_test.go
@@ -1,0 +1,93 @@
+package domain
+
+import (
+	"testing"
+)
+
+// TestPendingReferenceManager_AddReference 保留参照の追加テスト
+func TestPendingReferenceManager_AddReference(t *testing.T) {
+	manager := NewPendingReferenceManager()
+
+	// 未定義段落への参照を追加
+	pendingErr := manager.AddReference(1, "洞窟に入る", 23)
+	if pendingErr != nil {
+		t.Errorf("保留参照の追加に失敗: %v", pendingErr)
+	}
+
+	// 保留参照が正しく追加されていることを確認
+	references := manager.GetReferences(23)
+	if len(references) != 1 {
+		t.Errorf("保留参照数が不正: expected 1, got %d", len(references))
+	}
+
+	ref := references[0]
+	if ref.FromParagraph != 1 {
+		t.Errorf("参照元段落が不正: expected 1, got %d", ref.FromParagraph)
+	}
+	if ref.ChoiceDescription != "洞窟に入る" {
+		t.Errorf("選択肢説明が不正: expected '洞窟に入る', got '%s'", ref.ChoiceDescription)
+	}
+	if ref.TargetParagraph != 23 {
+		t.Errorf("参照先段落が不正: expected 23, got %d", ref.TargetParagraph)
+	}
+}
+
+// TestPendingReferenceManager_ResolveReference 保留参照の解決テスト
+func TestPendingReferenceManager_ResolveReference(t *testing.T) {
+	manager := NewPendingReferenceManager()
+
+	// 保留参照を追加
+	addErr := manager.AddReference(1, "洞窟に入る", 23)
+	if addErr != nil {
+		t.Fatalf("保留参照の追加に失敗: %v", addErr)
+	}
+
+	// 参照を解決
+	resolveErr := manager.ResolveReference(23)
+	if resolveErr != nil {
+		t.Errorf("保留参照の解決に失敗: %v", resolveErr)
+	}
+
+	// 解決後は保留参照が存在しないことを確認
+	references := manager.GetReferences(23)
+	if len(references) != 0 {
+		t.Errorf("解決後に保留参照が残存: expected 0, got %d", len(references))
+	}
+}
+
+// TestPendingReferenceManager_GetAllPendingTargets 全保留対象の取得テスト
+func TestPendingReferenceManager_GetAllPendingTargets(t *testing.T) {
+	manager := NewPendingReferenceManager()
+
+	// 複数の保留参照を追加
+	addErr1 := manager.AddReference(1, "洞窟に入る", 23)
+	if addErr1 != nil {
+		t.Fatalf("保留参照1の追加に失敗: %v", addErr1)
+	}
+
+	addErr2 := manager.AddReference(2, "森に進む", 45)
+	if addErr2 != nil {
+		t.Fatalf("保留参照2の追加に失敗: %v", addErr2)
+	}
+
+	addErr3 := manager.AddReference(3, "街に戻る", 23) // 同じ対象への複数参照
+	if addErr3 != nil {
+		t.Fatalf("保留参照3の追加に失敗: %v", addErr3)
+	}
+
+	// 全保留対象を取得
+	targets := manager.GetAllPendingTargets()
+	if len(targets) != 2 {
+		t.Errorf("保留対象数が不正: expected 2, got %d", len(targets))
+	}
+
+	// 対象に23と45が含まれることを確認
+	targetMap := make(map[int]bool)
+	for _, target := range targets {
+		targetMap[target] = true
+	}
+
+	if !targetMap[23] || !targetMap[45] {
+		t.Errorf("保留対象が不正: expected [23, 45], got %v", targets)
+	}
+}


### PR DESCRIPTION
## Summary
プレイテスターフィードバック(PLAY_FEEDBACK.md)で最高優先度(⭐⭐⭐⭐⭐)として特定された「段落順序依存問題」を完全に解消。本を読みながらの自然な記録フローを実現。

### 🔧 主要な実装
- **保留参照管理システム**: 未定義段落への参照を安全に管理
- **優雅なエラーハンドリング**: 未定義段落への移動で警告表示・処理続行
- **未定義段落への選択肢追加許可**: 遷移先が未定義でもエラーなし
- **自動解決機能**: 段落追加時に該当保留参照を自動削除

### 🎯 解決した問題
**従来**: `./gamebook choice 1 "洞窟に入る" 23` → エラー（段落23未定義）
**v0.2.1**: `./gamebook choice 1 "洞窟に入る" 23` → ✅ 成功（保留参照として記録）

**従来**: `./gamebook select 1 1` → エラー（移動先未定義）
**v0.2.1**: `./gamebook select 1 1` → ⚠️ 警告表示で処理続行、選択は記録

### 🧪 テスト実装
- TDD厳守で全機能をテストファーストで実装
- 保留参照管理、未定義段落選択肢、優雅な移動処理の包括テスト
- 全テスト通過、lintエラーゼロ

## Test plan
- [x] 未定義段落への選択肢追加テスト
- [x] 未定義段落への移動テスト（警告表示確認）
- [x] 保留参照の自動解決テスト
- [x] 既存機能への影響なし確認
- [x] 全単体テスト・統合テスト通過確認
- [x] Lint・フォーマット完了

🤖 Generated with [Claude Code](https://claude.ai/code)