### PR TITLE
[BUG FIX] Issue #90: domain.LoggerインターフェースにClose()メソッドを追加 - 全層統一修正

### DIFF
--- a/internal/domain/logger.go
+++ b/internal/domain/logger.go
@@ -19,4 +19,7 @@ type Logger interface {
 
 	// WithContext はコンテキストフィールドを追加した新しいロガーを返す
 	WithContext(fields ...Field) Logger
+
+	// Close はロガーのリソースをクリーンアップする
+	Close() error
 }

--- a/internal/domain/logger_test.go
+++ b/internal/domain/logger_test.go
@@ -41,6 +41,10 @@ func (m *MockLogger) WithContext(fields ...Field) Logger {
 	return newLogger
 }
 
+func (m *MockLogger) Close() error {
+	return nil
+}
+
 func (m *MockLogger) log(level LogLevel, msg string, fields []Field) {
 	allFields := make([]Field, len(m.fields)+len(fields))
 	copy(allFields, m.fields)

--- a/internal/usecase/logging_service.go
+++ b/internal/usecase/logging_service.go
@@ -157,6 +157,10 @@ func (c *contextLogger) WithContext(fields ...domain.Field) domain.Logger {
 	return c.service.WithContext(append(c.contextFields, fields...)...)
 }
 
+func (c *contextLogger) Close() error {
+	return c.service.Close()
+}
+
 // Close はリソースをクリーンアップする
 func (s *LoggingService) Close() error {
 	var closeErr error


### PR DESCRIPTION
## Summary
Issue #90で報告されたmockLoggerのClose()メソッドがdomain.Loggerインターフェースと不一致の問題を**全層統一修正**で解決しました。

## 🎯 修正内容

### **インターフェース一致の確保（全層統一）**
- **domain.Logger**: `Close() error`メソッドを追加
- **domain.MockLogger**: インターフェース準拠のClose()メソッドを実装
- **usecase.contextLogger**: サービス委譲のClose()メソッドを実装
- **infrastructure実装**: 既存のConsoleWriter, FileWriterは既にClose()実装済み

### **設計原則に基づく判断**
✅ **全層統一修正を採用した理由**:
1. **設計の一貫性**: 全実装で統一されたリソース管理が可能
2. **将来の拡張性**: ログファイルやネットワークロガーでもCloseが必要
3. **型安全性**: インターフェース統一により、コンパイル時に実装漏れを検出
4. **テストの堅牢性**: mockLoggerだけでなく、本番実装でもエラーケースをテスト可能

### **修正詳細**
- `internal/domain/logger.go`: Loggerインターフェースに`Close() error`を追加
- `internal/domain/logger_test.go`: MockLoggerに`Close() error`を実装（nilを返す）
- `internal/usecase/logging_service.go`: contextLoggerに`Close() error`を実装

## 📊 確認済み事項

### **既存実装との整合性**
- ✅ `internal/infrastructure/logger/console_writer.go`: Close()実装済み
- ✅ `internal/infrastructure/logger/file_writer.go`: Close()実装済み
- ✅ `internal/usecase/logging_service.go`: LoggingService.Close()実装済み

### **テスト結果**
- ✅ **全テスト通過**: `go test ./...` で全テスト正常動作
- ✅ **インターフェース契約**: MockLoggerが正しくLoggerインターフェースを実装
- ✅ **コンパイル時型チェック**: インターフェース一致によりエラー検出可能
- ✅ **回帰テスト**: 既存機能への影響なし

## 🔧 技術仕様

```go
// 修正前: インターフェース不一致
type Logger interface {
    // ... other methods
    WithContext(fields ...Field) Logger
}

// 修正後: 全層統一インターフェース
type Logger interface {
    // ... other methods
    WithContext(fields ...Field) Logger
    Close() error  // 追加
}
```

## 🚀 効果

1. **型安全性向上**: インターフェース一致により実行時エラーを防止
2. **統一リソース管理**: 全実装でCloseパターンが統一
3. **テスト品質向上**: エラーケースも含めた適切なテスト実行
4. **将来対応**: ファイルロガーやネットワークロガー追加時の一貫性確保
5. **CI/CD安定化**: テストの型チェックが正常動作

## 関連Issue
- Closes #90

🤖 Generated with [Claude Code](https://claude.ai/code)