### PR TITLE
[SUB-ISSUE E] Issue #92: CLIワンショットコマンドログ統合完了

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 📈 Current Status
 
 - **Version**: v0.2.8
-- **Latest**: Issue #72 (Choice number display improvement)
-- **Completed**: Improved choice number display format in show command
+- **Latest**: Issue #92 (CLI logging integration completion)
+- **Completed**: Unified all CLI commands to use CLIExecutor for consistent logging
+- **Previous**: Issue #72 (Choice number display improvement)
 - **History**: See `CHANGELOG.md`
 
 ## 🔄 Update History
 
+- 2025-07-07: Issue #92 completed - CLI logging system integration (all commands now use CLIExecutor)
 - 2025-07-06: Document structure optimization - Reduced token consumption by splitting documents
 - Earlier updates: See `CHANGELOG.md`
 

--- a/cmd/gamebook/choice_commands.go
+++ b/cmd/gamebook/choice_commands.go
@@ -13,40 +13,27 @@ var addChoiceCmd = &cobra.Command{
 	Short: "パラグラフに選択肢を追加",
 	Args:  cobra.ExactArgs(3),
 	Run: func(cmd *cobra.Command, args []string) {
-		if currentGame == nil {
-			fmt.Fprintln(os.Stderr, "エラー: ゲームブックが選択されていません。")
-			return
-		}
-
 		// パラグラフ番号をパース
-		paragraphNum, err := strconv.Atoi(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", err)
+		paragraphNum, paragraphErr := strconv.Atoi(args[0])
+		if paragraphErr != nil {
+			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", paragraphErr)
 			return
 		}
 
 		description := args[1]
 
 		// 遷移先パラグラフ番号をパース
-		targetNum, err := strconv.Atoi(args[2])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: 遷移先パラグラフ番号は数値で指定してください: %v\n", err)
+		targetNum, targetErr := strconv.Atoi(args[2])
+		if targetErr != nil {
+			fmt.Fprintf(os.Stderr, "エラー: 遷移先パラグラフ番号は数値で指定してください: %v\n", targetErr)
 			return
 		}
 
-		// 選択肢を追加
-		if err := currentGame.AddChoiceToParagraph(paragraphNum, description, targetNum); err != nil {
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteChoiceCommand(paragraphNum, description, targetNum); err != nil {
 			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
 		}
-
-		// 保存
-		if err := repo.Save(currentGame); err != nil {
-			fmt.Fprintf(os.Stderr, "保存エラー: %v\n", err)
-			return
-		}
-
-		fmt.Printf("パラグラフ %d に選択肢「%s → %d」を追加しました。\n", paragraphNum, description, targetNum)
 	},
 }
 
@@ -55,48 +42,25 @@ var selectChoiceCmd = &cobra.Command{
 	Short: "パラグラフの選択肢を選択し、遷移先に移動",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if currentGame == nil {
-			fmt.Fprintln(os.Stderr, "エラー: ゲームブックが選択されていません。")
-			return
-		}
-
 		// パラグラフ番号をパース
-		paragraphNum, err := strconv.Atoi(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", err)
+		paragraphNum, paragraphErr := strconv.Atoi(args[0])
+		if paragraphErr != nil {
+			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", paragraphErr)
 			return
 		}
 
 		// 選択肢番号をパース（1ベースから0ベースに変換）
-		choiceNum, err := strconv.Atoi(args[1])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: 選択肢番号は数値で指定してください: %v\n", err)
+		choiceNum, choiceErr := strconv.Atoi(args[1])
+		if choiceErr != nil {
+			fmt.Fprintf(os.Stderr, "エラー: 選択肢番号は数値で指定してください: %v\n", choiceErr)
 			return
 		}
 		choiceIndex := choiceNum - 1 // 1ベースから0ベースに変換
 
-		// 優雅なエラーハンドリングを使用して選択肢を選択・移動
-		moveResult := currentGame.SelectChoiceAndMoveWithGracefulHandling(paragraphNum, choiceIndex)
-
-		if !moveResult.Success {
-			fmt.Fprintf(os.Stderr, "エラー: %s\n", moveResult.WarningMessage)
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteSelectCommand(paragraphNum, choiceIndex); err != nil {
+			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
-		}
-
-		// 保存
-		if err := repo.Save(currentGame); err != nil {
-			fmt.Fprintf(os.Stderr, "保存エラー: %v\n", err)
-			return
-		}
-
-		// 結果の表示
-		if moveResult.HasWarning {
-			fmt.Printf("⚠️  警告: %s\n", moveResult.WarningMessage)
-			fmt.Printf("パラグラフ %d の選択肢 %d を選択しました（移動先が未定義のため現在位置を維持）。\n",
-				paragraphNum, choiceNum)
-		} else {
-			fmt.Printf("パラグラフ %d の選択肢 %d を選択し、パラグラフ %d に移動しました。\n",
-				paragraphNum, choiceNum, currentGame.Current.Number)
 		}
 	},
 }

--- a/cmd/gamebook/commands.go
+++ b/cmd/gamebook/commands.go
@@ -578,7 +578,7 @@ func (e *CLIExecutor) ExecuteListCommand() error {
 
 	titles, err := repo.List()
 	if err != nil {
-		LogErrorWithContext(err, "list_command", map[string]interface{}{})
+		LogErrorWithContext(err, "list_gamebooks", map[string]interface{}{})
 		LogCommandResult("list_gamebooks", false, map[string]interface{}{"error": err.Error()})
 		return fmt.Errorf("エラー: %v", err)
 	}

--- a/cmd/gamebook/commands.go
+++ b/cmd/gamebook/commands.go
@@ -30,6 +30,7 @@ type CommandExecutor interface {
 	ExecuteMoveCommand(targetNum int) error
 	ExecuteShowCommand() error
 	ExecuteShowCommandWithScope(scope DisplayScope) error
+	ExecuteListCommand() error
 }
 
 // CLIExecutor は実際のCLIコマンドを実行する
@@ -568,4 +569,39 @@ func formatChoicesDisplay(choices []domain.Choice) string {
 	}
 
 	return result.String()
+}
+
+// ExecuteListCommand listコマンドの実装を実行
+func (e *CLIExecutor) ExecuteListCommand() error {
+	// ユーザー操作記録
+	LogUserOperation("list_gamebooks", map[string]interface{}{})
+
+	titles, err := repo.List()
+	if err != nil {
+		LogErrorWithContext(err, "list_command", map[string]interface{}{})
+		LogCommandResult("list_gamebooks", false, map[string]interface{}{"error": err.Error()})
+		return fmt.Errorf("エラー: %v", err)
+	}
+
+	if len(titles) == 0 {
+		fmt.Println("保存されているゲームブックはありません。")
+		LogCommandResult("list_gamebooks", true, map[string]interface{}{"count": 0})
+		// ログにも記録
+		if logger := GetGlobalLogger(); logger != nil {
+			logger.Info("ゲームブック一覧表示", domain.Field{Key: "count", Value: 0})
+		}
+		return nil
+	}
+
+	fmt.Println("=== 保存されているゲームブック ===")
+	for i, title := range titles {
+		fmt.Printf("%d. %s\n", i+1, title)
+	}
+
+	LogCommandResult("list_gamebooks", true, map[string]interface{}{"count": len(titles)})
+	// ログにも記録
+	if logger := GetGlobalLogger(); logger != nil {
+		logger.Info("ゲームブック一覧表示", domain.Field{Key: "count", Value: len(titles)})
+	}
+	return nil
 }

--- a/cmd/gamebook/interactive_test.go
+++ b/cmd/gamebook/interactive_test.go
@@ -92,6 +92,13 @@ func (m *MockExecutor) ExecuteShowCommandWithScope(scope DisplayScope) error {
 	return nil
 }
 
+func (m *MockExecutor) ExecuteListCommand() error {
+	if m.ShouldError {
+		return fmt.Errorf("mock error")
+	}
+	return nil
+}
+
 func TestInteractiveShell_New(t *testing.T) {
 	// Setup: モックエグゼキューターを作成
 	mockExecutor := &MockExecutor{}

--- a/cmd/gamebook/load_commands.go
+++ b/cmd/gamebook/load_commands.go
@@ -16,9 +16,9 @@ var loadCmd = &cobra.Command{
 
 		if len(args) == 0 {
 			// タイトルが指定されていない場合、最後のゲームを取得
-			var err error
-			title, err = sessionRepo.GetCurrentGame()
-			if err != nil || title == "" {
+			var loadErr error
+			title, loadErr = sessionRepo.GetCurrentGame()
+			if loadErr != nil || title == "" {
 				fmt.Fprintln(os.Stderr, "エラー: 最後に使用したゲームブックが見つかりません。")
 				return
 			}
@@ -26,19 +26,11 @@ var loadCmd = &cobra.Command{
 			title = args[0]
 		}
 
-		gamebook, err := repo.Load(title)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "読み込みエラー: %v\n", err)
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteLoadCommand(title); err != nil {
+			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
 		}
-		currentGame = gamebook
-
-		// 現在のゲームとして保存
-		if err := sessionRepo.SaveCurrentGame(title); err != nil {
-			fmt.Fprintf(os.Stderr, "セッション保存エラー: %v\n", err)
-		}
-
-		fmt.Printf("ゲームブック「%s」を読み込みました。\n", title)
 	},
 }
 
@@ -46,20 +38,10 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "保存されているゲームブック一覧を表示",
 	Run: func(cmd *cobra.Command, args []string) {
-		titles, err := repo.List()
-		if err != nil {
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteListCommand(); err != nil {
 			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
-		}
-
-		if len(titles) == 0 {
-			fmt.Println("保存されているゲームブックはありません。")
-			return
-		}
-
-		fmt.Println("=== 保存されているゲームブック ===")
-		for i, title := range titles {
-			fmt.Printf("%d. %s\n", i+1, title)
 		}
 	},
 }

--- a/cmd/gamebook/main.go
+++ b/cmd/gamebook/main.go
@@ -111,19 +111,11 @@ var newCmd = &cobra.Command{
 	Short: "新しいゲームブックを作成",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		title := args[0]
-		currentGame = domain.NewGamebook(title)
-		if err := repo.Save(currentGame); err != nil {
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteNewCommand(args[0]); err != nil {
 			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
 		}
-
-		// 現在のゲームとして保存
-		if err := sessionRepo.SaveCurrentGame(title); err != nil {
-			fmt.Fprintf(os.Stderr, "セッション保存エラー: %v\n", err)
-		}
-
-		fmt.Printf("新しいゲームブック「%s」を作成しました。\n", title)
 	},
 }
 
@@ -132,30 +124,18 @@ var addCmd = &cobra.Command{
 	Short: "パラグラフを追加",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		if currentGame == nil {
-			fmt.Fprintln(os.Stderr, "エラー: ゲームブックが選択されていません。'gamebook new'または'gamebook load'を実行してください。")
-			return
-		}
-
-		number, err := strconv.Atoi(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", err)
+		number, numberErr := strconv.Atoi(args[0])
+		if numberErr != nil {
+			fmt.Fprintf(os.Stderr, "エラー: パラグラフ番号は数値で指定してください: %v\n", numberErr)
 			return
 		}
 		description := args[1]
 
-		p := domain.NewParagraph(number, description)
-		if err := currentGame.AddParagraph(p); err != nil {
+		executor := NewCLIExecutor()
+		if err := executor.ExecuteAddCommand(number, description); err != nil {
 			fmt.Fprintf(os.Stderr, "エラー: %v\n", err)
 			return
 		}
-
-		if err := repo.Save(currentGame); err != nil {
-			fmt.Fprintf(os.Stderr, "保存エラー: %v\n", err)
-			return
-		}
-
-		fmt.Printf("パラグラフ %d を追加しました: %s\n", number, description)
 	},
 }
 

--- a/docs/dev/logging-system.md
+++ b/docs/dev/logging-system.md
@@ -1,0 +1,259 @@
+# ログシステム使用ガイド
+
+## 概要
+
+iwakero-gamebook-mappingのログシステムは、AI開発効率化を目的とした構造化ログシステムです。
+Clean Architecture 4層（Entities, Usecase, Interface Adapters, Frameworks）全体で統一されたログ出力を提供します。
+
+## 🎯 目的
+
+- **AI開発効率化**: 構造化されたログで開発状況を把握
+- **デバッグ支援**: エラーの詳細なコンテキスト情報
+- **操作追跡**: ユーザー操作の記録と分析
+- **品質向上**: バリデーション結果と設定変更の記録
+
+## 🏗️ アーキテクチャ
+
+### 4層設計
+```
+┌─────────────────────────────────────┐
+│ Frameworks Layer (cmd/gamebook/)    │ ← ログシステム統合
+├─────────────────────────────────────┤
+│ Interface Adapters Layer            │ ← Repository/Presenter/Controller
+├─────────────────────────────────────┤
+│ Usecase Layer                       │ ← アプリケーションロジック
+├─────────────────────────────────────┤
+│ Entities Layer (internal/domain/)   │ ← Loggerインターフェース
+└─────────────────────────────────────┘
+```
+
+### 主要コンポーネント
+- **domain.Logger**: ログインターフェース定義
+- **LoggingController**: 設定管理とログライター制御
+- **StructuredLogger**: AI開発最適化されたログフォーマット
+- **OperationLogger**: 高レベル操作ログ関数
+
+## ✅ 実装状況
+
+### Issue #92完了: CLI統一実装
+**2025-07-07時点**: すべてのCLIワンショットコマンドでログ出力が正常動作します。
+
+#### 対応済みコマンド
+- `./gamebook new "タイトル"` - ゲームブック作成
+- `./gamebook add 1 "説明"` - パラグラフ追加
+- `./gamebook choice 1 "選択肢" 2` - 選択肢追加
+- `./gamebook select 1 1` - 選択肢選択
+- `./gamebook move 2` - パラグラフ移動
+- `./gamebook load "タイトル"` - ゲームブック読み込み
+- `./gamebook list` - ゲームブック一覧
+- `./gamebook show` - 状態表示
+
+#### CLIログ出力確認
+```bash
+export LOG_LEVEL=DEBUG
+export LOG_OUTPUT=stderr  
+export GAMEBOOK_AI_DEV=true
+./gamebook new "テストゲーム" 2>&1 | grep -E "(DEBUG|INFO|WARN|ERROR)"
+```
+
+期待される出力例:
+```
+2025-07-07T04:44:25+09:00 [INFO] [operation.new_gamebook] ゲームブック作成 | title="テストゲーム" | commands.go:85
+```
+
+## 🚀 基本使用方法
+
+### 1. 環境変数設定
+
+```bash
+# ログレベル設定
+export LOG_LEVEL=DEBUG    # DEBUG, INFO, WARN, ERROR, FATAL
+
+# 出力先設定
+export LOG_OUTPUT=console # console, stderr, file
+
+# フォーマット設定
+export LOG_FORMAT=text    # text, json
+
+# AI開発モード（自動DEBUGレベル、詳細出力）
+export GAMEBOOK_AI_DEV=true
+
+# ファイル出力時のパス
+export LOG_FILE_PATH=/path/to/logfile.log
+```
+
+### 2. YAML設定ファイル
+
+`~/.gamebook/logger.yaml`:
+```yaml
+level: DEBUG
+format: text
+output: console
+file_path: ""
+```
+
+### 3. コード内での使用
+
+#### 基本ログ出力
+```go
+// Frameworks Layer
+logger := GetGlobalLogger()
+logger.Info("ゲームブック作成", domain.Field{Key: "title", Value: "冒険の書"})
+logger.Error("ファイル読み込みエラー", domain.Field{Key: "path", Value: "/data/game.md"})
+```
+
+#### 操作ログ（推奨）
+```go
+// ユーザー操作記録
+LogUserOperation("new_gamebook", map[string]interface{}{
+    "title": "新しいゲーム",
+    "title_length": 12,
+})
+
+// バリデーションエラー記録
+LogValidationError("title", title, "空のタイトル", map[string]interface{}{
+    "command": "new",
+})
+
+// コマンド結果記録
+LogCommandResult("new", true, "ゲームブック作成成功", map[string]interface{}{
+    "file_path": "./data/game.md",
+})
+
+// UI操作記録（AI開発モード時のみ）
+LogUIInteraction("menu_selection", map[string]interface{}{
+    "selected_option": "新しいゲーム",
+    "selection_time_ms": 245.67,
+})
+```
+
+## 🎨 ログフォーマット
+
+### テキストフォーマット（AI開発最適化）
+```
+2025-07-06T19:30:15+09:00 [INFO] [operation.new_gamebook] ゲームブック作成 | title="冒険の書" duration=15.23ms | gamebook.go:45 | session: current_game=true paragraphs=0
+```
+
+### JSONフォーマット
+```json
+{
+  "timestamp": "2025-07-06T19:30:15+09:00",
+  "level": "INFO",
+  "category": "operation",
+  "action": "new_gamebook",
+  "component": "gamebook",
+  "message": "ゲームブック作成",
+  "context": {"title": "冒険の書"},
+  "performance": {"duration_ms": 15.23, "success": true},
+  "location": {"file": "gamebook.go", "line": 45, "function": "ExecuteNewCommand"},
+  "session": {"has_current_game": true, "total_paragraphs": 0}
+}
+```
+
+## 🤖 AI開発モード
+
+### 有効化
+```bash
+export GAMEBOOK_AI_DEV=true
+```
+
+### 特徴
+- **自動DEBUGレベル**: `LOG_LEVEL`を自動的にDEBUGに昇格
+- **詳細出力**: パフォーマンス情報、ソースコード位置、セッション状態
+- **UI操作ログ**: メニュー選択、入力操作の詳細記録
+- **構造化フォーマット**: AI解析に最適化された出力
+
+### AI開発モード時の追加情報
+- **パフォーマンス**: 処理時間、成功/失敗ステータス
+- **ソースコード位置**: ファイル名、行番号、関数名
+- **セッション状態**: 現在のゲーム状態、パラグラフ数
+- **操作コンテキスト**: 入力値、選択肢、タイミング情報
+
+## 📂 設定ファイル優先順位
+
+1. **環境変数** (最優先)
+2. **YAML設定ファイル** (`~/.gamebook/logger.yaml`)
+3. **デフォルト設定** (INFO, text, console)
+
+## 🔧 トラブルシューティング
+
+### ログが出力されない
+```bash
+# 設定確認
+env | grep -E "(LOG_|GAMEBOOK_)"
+
+# デバッグモード有効化
+export LOG_LEVEL=DEBUG
+export GAMEBOOK_AI_DEV=true
+
+# stderr出力に変更
+export LOG_OUTPUT=stderr
+```
+
+### パフォーマンス問題
+```bash
+# ログレベルを上げる
+export LOG_LEVEL=WARN
+
+# AI開発モードを無効化
+unset GAMEBOOK_AI_DEV
+```
+
+## 🎯 ベストプラクティス
+
+### 1. 適切なレベル選択
+- **DEBUG**: 開発時の詳細追跡
+- **INFO**: 通常操作の記録
+- **WARN**: 注意が必要な状況
+- **ERROR**: エラー発生時
+- **FATAL**: アプリケーション終了レベル
+
+### 2. 構造化データ活用
+```go
+// 良い例: 構造化されたフィールド
+LogUserOperation("add_paragraph", map[string]interface{}{
+    "paragraph_id": 42,
+    "description_length": len(description),
+    "has_choices": hasChoices,
+})
+
+// 悪い例: 文字列内に情報を埋め込み
+logger.Info(fmt.Sprintf("パラグラフ%d追加: %s", id, description))
+```
+
+### 3. AI開発モード活用
+- 開発中: `GAMEBOOK_AI_DEV=true`で詳細ログ
+- 本番: `GAMEBOOK_AI_DEV=false`で最小限ログ
+
+## 🔗 関連ファイル
+
+- `cmd/gamebook/logger_setup.go` - 初期化
+- `cmd/gamebook/logger_config.go` - 設定管理  
+- `cmd/gamebook/structured_logger.go` - フォーマット
+- `cmd/gamebook/operation_logger.go` - 操作ログ関数
+- `internal/domain/logger.go` - インターフェース定義
+
+## 📋 設定例
+
+### 開発環境
+```bash
+export LOG_LEVEL=DEBUG
+export LOG_OUTPUT=stderr
+export LOG_FORMAT=text
+export GAMEBOOK_AI_DEV=true
+```
+
+### 本番環境
+```bash
+export LOG_LEVEL=WARN
+export LOG_OUTPUT=file
+export LOG_FORMAT=json
+export LOG_FILE_PATH=/var/log/gamebook.log
+```
+
+### テスト環境
+```bash
+export LOG_LEVEL=ERROR
+export LOG_OUTPUT=console
+export LOG_FORMAT=text
+```

--- a/test/cli_integration_test.go
+++ b/test/cli_integration_test.go
@@ -36,8 +36,8 @@ func TestCLIWorkflow(t *testing.T) {
 		assert.NoError(t, err, "new command should succeed")
 		assert.Contains(t, string(output), "テストブック")
 
-		// 2. 作成直後にパラグラフを追加できるかテスト
-		cmd = exec.Command(binaryPath, "add", "1", "開始地点")
+		// 2. 作成直後にパラグラフを追加できるかテスト（パラグラフ1は自動作成されるので2を使用）
+		cmd = exec.Command(binaryPath, "add", "2", "第二の部屋")
 		cmd.Dir = tmpDir
 		cmd.Env = append(os.Environ(), "GAMEBOOK_DATA_DIR="+dataDir)
 		output, err = cmd.CombinedOutput()
@@ -46,7 +46,7 @@ func TestCLIWorkflow(t *testing.T) {
 		if err != nil {
 			t.Logf("Expected failure: %s", string(output))
 		} else {
-			assert.Contains(t, string(output), "パラグラフ 1 を追加しました")
+			assert.Contains(t, string(output), "パラグラフ 2 を追加しました")
 		}
 	})
 
@@ -61,17 +61,15 @@ func TestCLIWorkflow(t *testing.T) {
 		require.NoError(t, err)
 
 		// 2. パラグラフ追加（load不要であるべき）
-		cmd = exec.Command(binaryPath, "add", "1", "最初の場所")
+		cmd = exec.Command(binaryPath, "add", "3", "三番目の場所")
 		cmd.Dir = tmpDir
 		cmd.Env = append(os.Environ(), "GAMEBOOK_DATA_DIR="+dataDir)
 		output, err := cmd.CombinedOutput()
 
-		// この操作が成功することを期待
+		// この操作が成功することを期待（パラグラフ3は新規作成）
 		t.Logf("Add output: %s", string(output))
-		if err != nil {
-			t.Logf("Expected failure: %v", err)
-		}
-		// assert.NoError(t, err) // 現在は失敗するのでコメントアウト
+		assert.NoError(t, err, "add command should succeed")
+		assert.Contains(t, string(output), "パラグラフ 3 を追加しました")
 	})
 
 	t.Run("最後に使用したゲームブックの自動ロード", func(t *testing.T) {


### PR DESCRIPTION
## 概要

Issue #80の最終Sub-Issue #92完了: CLIワンショットコマンドでログが出力されない問題を解決

## 変更内容

### 問題の解決
- **Cobraコマンドの二重実装解消**: 直接`fmt.Printf`を使用していたCobraコマンドをCLIExecutorメソッド経由に統一
- **統一されたログシステム**: 対話モード・CLIモード両方で構造化ログが正常出力

### 具体的な修正
- `main.go`: newCmd/addCmdをCLIExecutor統一
- `choice_commands.go`: addChoiceCmd/selectChoiceCmdをCLIExecutor統一  
- `load_commands.go`: loadCmd/listCmdをCLIExecutor統一
- `commands.go`: ExecuteListCommand()メソッド追加
- `interactive_test.go`: MockExecutorにExecuteListCommand()追加
- `docs/dev/logging-system.md`: Issue #92完了状況を反映

### 検証済み動作
```bash
export LOG_LEVEL=DEBUG; export GAMEBOOK_AI_DEV=true
./gamebook new "テストゲーム" 2>&1  < /dev/null |  grep -E "(DEBUG|INFO|WARN|ERROR)"
# 期待されるログが正常出力されることを確認
```

## テスト計画

- [x] 全テストが通過することを確認
- [x] golangci-lintエラーなしを確認  
- [x] CLIコマンドでログ出力機能の動作確認
- [x] Variable Shadowingなし（コーディング規約遵守）
- [x] TDD方針準拠（既存テストの修正のみ）
- [x] CLAUDE.md更新
- [x] logging-system.md更新（完了状況反映）

🤖 Generated with [Claude Code](https://claude.ai/code)